### PR TITLE
length: specify command accepts a key type

### DIFF
--- a/src/commands/length.md
+++ b/src/commands/length.md
@@ -4,7 +4,7 @@ The `length` command returns the length of a Bytes, List, Map, Set, or String. A
 key type can be specified to limit the operation to only calculating the length
 of the key if it matches the specified type.
 
-Usage: `length <key>`
+Usage: `length[:key_type] <key>`
 
 CLI example:
 


### PR DESCRIPTION
Specify that the `length` command accepts a key type in the usage
example.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>