### PR TITLE
commands: fix cli examples

### DIFF
--- a/src/commands/delete.md
+++ b/src/commands/delete.md
@@ -9,7 +9,7 @@ Usage: `delete <key>`
 CLI example:
 
 ```
-> set foo:list item1 item2 item1
+> set:list foo item1 item2 item1
 item1
 item2
 item1

--- a/src/commands/exists.md
+++ b/src/commands/exists.md
@@ -11,11 +11,11 @@ Usage: `exists <key> [keys...]`
 CLI example:
 
 ```
-> set foo:bool false
+> set:bool foo false
 false
 > exists foo
 true
-> set bar:map a b c d
+> set:map bar a b c d
 a=b
 c=d
 > exists foo bar

--- a/src/commands/length.md
+++ b/src/commands/length.md
@@ -9,14 +9,14 @@ Usage: `length[:key_type] <key>`
 CLI example:
 
 ```
-> set foo:map key1 value1 key2 value2
+> set:map foo key1 value1 key2 value2
 key1=value1 key2=value2
 > length foo
 2
-> length foo:list
+> length:list foo
 Dispatch error: the key "foo" isn't a List.
-> set bar:set item1 item2 item1
+> set:set bar item1 item2 item1
 item1 item2
-> length foo:set
+> length:set foo
 2
 ```

--- a/src/commands/rename.md
+++ b/src/commands/rename.md
@@ -15,11 +15,11 @@ CLI example:
 The key to rename is required.
 > rename foo bar
 Dispatch error: key "foo" doesn't exist.
-> set foo:int 123
+> set:int foo 123
 123
 > rename foo bar
 bar
-> set foo:int 456
+> set:int foo 456
 456
 > rename foo bar
 Dispatch error: the destination key, "bar", already exists.


### PR DESCRIPTION
Fix the CLI examples for commands, which had the key type in the wrong
place. The key types were at the position after the key name, but they
should be after the command name.

This fixes documentation for the following commands:

- delete
- exists
- length
- rename

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>