### PR TITLE
commands: add 'is' command

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -13,6 +13,7 @@
   - [exists](./commands/exists.md)
   - [increment](./commands/increment.md)
     - [increment:by](./commands/increment_by.md)
+  - [is](./commands/is.md)
   - [length](./commands/length.md)
   - [rename](./commands/rename.md)
   - [stats](./commands/stats.md)

--- a/src/commands/is.md
+++ b/src/commands/is.md
@@ -1,0 +1,62 @@
+# is
+
+Usage: `is<:key_type> <key> [keys...]`
+
+The `is` command checks if all of the provided key names are of a certain key
+type. If at least one key does not exist or is not the specified key type,
+then `false` is returned, otherwise `true` is returned.
+
+At least one key must be provided. A key type must also be provided.
+
+## Errors
+
+If a key type is not specified, then a `DispatchError::KeyTypeRequired` error is
+returned.
+
+If no arguments are provided, then a `DispatchError::ArgumentRetrieval` error is
+returned.
+
+## Examples
+
+### CLI
+
+```
+> set:bool foo false
+false
+> is:bool foo # foo is a bool
+true
+> is:int foo # foo is not an int
+false
+> set:int bar 123
+123
+> is:bool foo bar # foo is a bool, but bar is not
+false
+> is:bool foo baz # foo is a bool, but baz does not exist
+false
+```
+
+### Client
+
+```rust
+use hop::{Client, KeyType};
+
+let client = Client::memory();
+
+// set a key named "foo" to a boolean with a value of false
+client.set("foo").bool(false).await?;
+
+// foo is a bool
+assert!(client.is(KeyType::Boolean).key("foo").await?);
+
+// foo is not an int
+assert!(!client.is(KeyType::Integer).key("foo").await?);
+
+// set a key named "bar" to an integer with a value of 123
+client.set("bar").int(123).await?;
+
+// foo is a bool, but bar is not
+assert!(!client.is(KeyType::Boolean).keys(&["foo", "bar"]).await?);
+
+// foo is a bool, but baz does not exist
+assert!(!client.is(KeyType::Boolean).keys(&["foo", "baz"]).await?);
+```

--- a/src/commands/stats.md
+++ b/src/commands/stats.md
@@ -19,7 +19,7 @@ Usage: `stats`
 CLI example:
 
 ```python
-> set foo:int 1234
+> set:int foo 1234
 1234
 > stats
 Commands successful: 1


### PR DESCRIPTION
Add the 'is' command, matching the commit made over at hop:
<https://github.com/hopdb/hop/commit/44a276fc19f3ca023cf80ccd7508b77f2c19ba45>

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>