### PR TITLE
commands: make pages consistent in design

### DIFF
--- a/src/commands/append.md
+++ b/src/commands/append.md
@@ -1,8 +1,8 @@
 # append
 
-Usage: `append[:key_type] <key> [value...]`
+**Usage**: `append[:key_type] <key> [value...]`
 
-Supported key types: `bytes`, `list`, `string`
+**Supported key types**: `bytes`, `list`, `string`
 
 The `append` command appends a value to a key depending on the key's type. If
 the key type is a `bytes`, then the given argument will be appended to the
@@ -15,15 +15,14 @@ one will restrict the operation to the key type and error if it is different.
 
 ## Errors
 
-If a key type is not specified, then a `DispatchError::KeyUnspecified` is
-returned.
+If a key is not specified then a `DispatchError::KeyUnspecified` is returned.
 
-If no value is provided, then a `DispatchError::ArgumentRetrieval` is returned.
+If no value is provided then a `DispatchError::ArgumentRetrieval` is returned.
 
-If the command does not support the specified key type, than a
-DispatchError::KeyTypeInvalid` is returned.
+If the command does not support the specified key type then a
+`DispatchError::KeyTypeInvalid` is returned.
 
-If a provided value is of the wrong type, then a
+If a provided value is of the wrong type then a
 `DispatchError::KeyTypeDifferent` is returned.
 
 ## Examples

--- a/src/commands/decrement.md
+++ b/src/commands/decrement.md
@@ -1,19 +1,26 @@
 # decrement
 
+**Usage**: `decrement[:key_type] <key>`
+
+**Supported key types**: `float`, `integer`
+
 The `decrement` command takes a key argument and decrements a float or integer
 by 1. If the key doesn't already exist, then a default value of 0 is set and
 then decremented.
 
-A key type of Float or Integer may be specified. If a different key type is
-specified then an error is returned.
+## Errors
 
-If a key exists of a different type than the specified key type, then an error
-is returned. For example, if a Float key type is specified but a key exists
-which is an Integer, then the command will error.
+If a key is not specified, then a `DispatchError::KeyUnspecified` is returned.
 
-Usage: `decrement[:key_type] <key>`
+If the command does not support the specified key type, then a
+`DispatchError::KeyTypeInvalid` is returned.
 
-CLI example:
+If the type of the key is different than the specified key type, then a
+`DispatchError::KeyTypeDifferent` is returned.
+
+## Examples
+
+### CLI
 
 ```
 > decrement foo # foo will be an integer since that is the default type
@@ -26,4 +33,23 @@ Dispatch error: key "foo" is not a float.
 -2.0
 > decrement foo
 -2
+```
+
+### Client
+
+```rust
+use hop::{Client, KeyType};
+
+let client = Client::memory();
+
+assert_eq!(-1, client.decrement("foo").await?);
+
+// Dispatch error: key "foo" is not a float.
+assert!(client.decrement("foo").float().await.is_err());
+
+assert!(client.decrement("bar").float().await.is_ok());
+
+assert!(client.decrement("bar").float().await.is_ok());
+
+assert_eq!(-2, client.decrement("foo").int().await?);
 ```

--- a/src/commands/delete.md
+++ b/src/commands/delete.md
@@ -1,12 +1,26 @@
 # delete
 
+**Usage**: `delete <key>`
+
+**Supported key types**: none
+
 The `delete` command deletes a key by name. A key type can't be specified, and
 regardless of type the key will be deleted if it exists. The key's name is
 returned on success as confirmation.
 
-Usage: `delete <key>`
+## Errors
 
-CLI example:
+If a key type is specified then a `DispatchError::KeyTypeUnexpected` is
+returned.
+
+If a key is not specified then a `DispatchError::KeyUnspecified` is returned.
+
+If the key does not exist then a `DispatchError::PreconditionFailed` is
+returned.
+
+## Examples
+
+### CLI
 
 ```
 > set:list foo item1 item2 item1

--- a/src/commands/echo.md
+++ b/src/commands/echo.md
@@ -1,12 +1,20 @@
 # echo
 
+**Usage**: `echo [argument...]`
+
+**Supported key types**: none
+
 The `echo` command echoes back the provided arguments as a list of the same
 arguments. If no arguments are echoed, then an empty list is returned. A key
 type can't be specified.
 
-Usage: `echo [argument...]`
+## Errors
 
-CLI example:
+This command doesn't error.
+
+## Examples
+
+### CLI
 
 ```
 > echo foo bar baz
@@ -16,6 +24,5 @@ baz
 > echo echo
 echo
 > echo
-
 
 ```

--- a/src/commands/exists.md
+++ b/src/commands/exists.md
@@ -1,14 +1,25 @@
 # exists
 
+**Usage**: `exists <key> [keys...]`
+
+**Supported key types**: none
+
 The `exists` command checks if all of the provided key names exist. If at least
 one key does not exist, then `false` is returned, otherwise `true` is returned.
 
 At least one key must be provided, up to the global limit of 255. If you need to
 check that more exist, use multiple commands.
 
-Usage: `exists <key> [keys...]`
+## Errors
 
-CLI example:
+If a key type is specified then a `DispatchError::KeyTypeUnexpected` is
+returned.
+
+If no key is provided then a `DispatchError::ArgumentRetrieval` is returned.
+
+## Examples
+
+### CLI
 
 ```
 > set:bool foo false

--- a/src/commands/increment.md
+++ b/src/commands/increment.md
@@ -1,19 +1,26 @@
 # increment
 
+**Usage**: `decrement[:key_type] <key>`
+
+**Supported key types**: `float`, `integer`
+
 The `increment` command takes a key argument and increments a float or integer
 by 1. If the key doesn't already exist, then a default value of 0 is set and
 then incremented.
 
-A key type of Float or Integer may be specified. If a different key type is
-specified then an error is returned.
+## Errors
 
-If a key exists of a different type than the specified key type, then an error
-is returned. For example, if a Float key type is specified but a key exists
-which is an Integer, then the command will error.
+If a key is not specified, then a `DispatchError::KeyUnspecified` is returned.
 
-Usage: `increment[:key_type] <key>`
+If the command does not support the specified key type, then a
+`DispatchError::KeyTypeInvalid` is returned.
 
-CLI example:
+If the type of the key is different than the specified key type, then a
+`DispatchError::KeyTypeDifferent` is returned.
+
+## Examples
+
+### CLI
 
 ```
 > increment foo # foo will be an integer since that is the default type
@@ -26,4 +33,23 @@ Dispatch error: key "foo" is not a float.
 2.0
 > increment foo
 2
+```
+
+### Client
+
+```rust
+use hop::{Client, KeyType};
+
+let client = Client::memory();
+
+assert_eq!(1, client.increment("foo").await?);
+
+// Dispatch error: key "foo" is not a float.
+assert!(client.increment("foo").float().await.is_err());
+
+assert!(client.increment("bar").float().await.is_ok());
+
+assert!(client.increment("bar").float().await.is_ok());
+
+assert_eq!(2, client.increment("foo").int().await?);
 ```

--- a/src/commands/increment_by.md
+++ b/src/commands/increment_by.md
@@ -1,20 +1,27 @@
 # increment:by
 
+**Usage**: `increment:by[:key_type] <key> <amount>`
+
+**Supported key types**: `float`, `integer`
+
 The `increment:by` command is a sub-command of `increment`, and like `increment`
 it takes a key argument. An additional argument must be provided which specifies
 the amount to increment the value by. If the key doesn't already exist, then a
 default value of 0 is set and then incremented by the specified amount.
 
-A key type of Float or Integer may be specified. If a different key type is
-specified then an error is returned.
+## Errors
 
-If a key exists of a different type than the specified key type, then an error
-is returned. For example, if a Float key type is specified but a key exists
-which is an Integer, then the command will error.
+If a key is not specified then a `DispatchError::KeyUnspecified` is returned.
 
-Usage: `increment:by[:key_type] <key> <amount>`
+If a value is not specified then a `DispatchError::ArgumentRetrieval` is
+returned.
 
-CLI example:
+If the key type was specified and it is different than the key's type a
+`DispatchError::KeyTypeDifferent` is returned.
+
+## Examples
+
+### CLI
 
 ```
 > increment:by foo 3 # foo will be an integer since that is the default type
@@ -27,4 +34,23 @@ Dispatch error: key "foo" is not a float.
 5.0
 > increment:by foo 3
 6
+```
+
+### Client
+
+```rust
+use hop::{Client, KeyType};
+
+let client = Client::memory();
+
+assert_eq!(3, client.increment("foo").int().by(3).await?);
+
+// Dispatch error: key "foo" is not a float.
+assert!(client.increment("foo").float().by(2.0).await.is_err());
+
+assert!(client.increment("bar").float().by(2.0).await.is_ok());
+
+assert!(client.increment("bar").float().by(3.0).await.is_ok());
+
+assert_eq!(6, client.increment("foo").int().by(3).await?);
 ```

--- a/src/commands/is.md
+++ b/src/commands/is.md
@@ -1,6 +1,9 @@
 # is
 
-Usage: `is<:key_type> <key> [keys...]`
+**Usage**: `is<:key_type> <key> [keys...]`
+
+**Supported key types**: `boolean`, `bytes`, `float`, `integer`, `list`, `map`,
+`set`, `string`
 
 The `is` command checks if all of the provided key names are of a certain key
 type. If at least one key does not exist or is not the specified key type,

--- a/src/commands/length.md
+++ b/src/commands/length.md
@@ -1,12 +1,29 @@
 # length
 
-The `length` command returns the length of a Bytes, List, Map, Set, or String. A
-key type can be specified to limit the operation to only calculating the length
-of the key if it matches the specified type.
+**Usage**: `length[:key_type] <key>`
 
-Usage: `length[:key_type] <key>`
+**Supported key types**: `bytes`, `list`, `map`, `set`, `string`
 
-CLI example:
+The `length` command returns the length of some bytes, a list, map, set, or
+string. A key type can be specified to limit the operation to only calculating
+the length of the key if it matches the specified type.
+
+## Errors
+
+If a key is not specified then a `DispatchError::KeyUnspecified` is returned.
+
+If a specified key type is not supported than a `DispatchError::KeyTypeInvalid`
+is returned.
+
+If the specified key does not exist thyen a `DispatchError::KeyNonexistent`
+is returned.
+
+If the key type of the key is different than the specified key type then a
+`DispatchError::KeyTypeDifferent` is returned.
+
+## Examples
+
+### CLI
 
 ```
 > set:map foo key1 value1 key2 value2

--- a/src/commands/rename.md
+++ b/src/commands/rename.md
@@ -1,14 +1,34 @@
 # rename
 
+**Usage**: `rename <from> <to>`
+
+**Supported key types**: none
+
 The `rename` command renames a key by moving the value from one key to another.
-The source key must have a value, and the destination key must not already be
-present.
+The source key must exist, and the destination key must not already be taken.
 
 The destination key name is returned on success as confirmation.
 
-Usage: `rename <from> <to>`
+## Errors
 
-CLI example:
+If a key type is specified then a `DispatchError::KeyTypeUnexpected` is
+returned.
+
+If a source key is not specified then a `DispatchError::KeyUnspecified` is
+returned.
+
+If a destination key is not specified then a `DispatchError::ArgumentRetrieval`
+is returned.
+
+If the source key does not exist then a `DispatchError::KeyNonexistent` is
+returned.
+
+If the destination key does not exist then a `DispatchError::PreconditionFailed`
+is returned.
+
+## Examples
+
+### CLI
 
 ```
 > rename

--- a/src/commands/set.md
+++ b/src/commands/set.md
@@ -1,6 +1,9 @@
 # set
 
-Usage: `set[:key_type] <key> <value...>`
+**Usage**: `set[:key_type] <key> <value...>`
+
+**Supported key types**: `boolean`, `bytes`, `float`, `integer`, `list`, `map`,
+`set`, `string`
 
 The `set` command sets a value to a key, overriding the existing key's value if
 one exists. The `set` command supports setting values of all types.
@@ -10,14 +13,14 @@ type is raw bytes.
 
 ## Errors
 
-If a key type set not specified, then a `DispatchError::KeyUnspecified` error is
+If a key type is not specified then a `DispatchError::KeyUnspecified` error is
 returned.
 
-If no value is provided, then a `DispatchError::ArgumentRetrieval` error is
+If no value is provided then a `DispatchError::ArgumentRetrieval` error is
 returned.
 
-If a provided value is of the wrong type, then a `DispatchError::WrongType`
-error is returned.
+If a provided value is of the wrong type then a
+`DispatchError::KeyTypeDifferent` error is returned.
 
 ## Examples
 

--- a/src/commands/stats.md
+++ b/src/commands/stats.md
@@ -1,5 +1,9 @@
 # stats
 
+**Usage**: `stats`
+
+**Supported key types**: none
+
 The `stats` command returns a Map of statistics about the Hop instance. The Hop
 engine maintains metrics about operations and its current state.
 
@@ -14,9 +18,14 @@ initiated.
 - **sessions_ended**: the number of client sessions that have finished for one
 reason or another.
 
-Usage: `stats`
+## Errors
 
-CLI example:
+If a key type is specified then a `DispatchError::KeyTypeUnexpected` is
+returned.
+
+## Examples
+
+### CLI
 
 ```python
 > set:int foo 1234


### PR DESCRIPTION
Make the command pages consistent in their design of information.

The pages all start with their usage and supported key types, followed by a summary of the command. A section with a list of possible errors follows, and then a section with examples. One or two example sub-sections are included using the CLI and Rust client.